### PR TITLE
Fix typo in method name

### DIFF
--- a/lib/Crypt/Perl/ECDSA/EncodedPoint.pm
+++ b/lib/Crypt/Perl/ECDSA/EncodedPoint.pm
@@ -40,7 +40,7 @@ sub new {
         $self->{'_compressed_bin'} = $bin;
     }
     else {
-        die Crypt::Perl::X::Create('Generic', sprintf "Invalid leading octet in ECDSA point: %v02x", $bin);
+        die Crypt::Perl::X::create('Generic', sprintf "Invalid leading octet in ECDSA point: %v02x", $bin);
     }
 
     return $self;


### PR DESCRIPTION
<s>Reproduce</s> This is not reproduce it. I think dependencies in my environment was broken.
```bash
$ cat example.pl
#!/usr/bin/perl

use Crypt::Perl::ECDSA::Parse;

my $secret = <<'KEY';
-----BEGIN EC PRIVATE KEY-----
MHcCAQEEIMOIMq/VpgIYwlTg8Ddpj2mu1lunxSR3iTdNfL/M4hTHoAoGCCqGSM49
AwEHoUQDQgAExuUsglRa5j9/utTLtKweCa5aX7X30qZJkpwuq3CjJO1U6yG+aVkp
k+GC9lpydXt/jY5s8CpawZGUWcB3sLYopg==
-----END EC PRIVATE KEY-----
KEY

Crypt::Perl::ECDSA::Parse::private($secret);

$ perl -I lib example.pl
Undefined subroutine &Crypt::Perl::X::Create called at lib/Crypt/Perl/ECDSA/EncodedPoint.pm line 43.
```