### PR TITLE
Add a way to generate deterministic signatures without digesting

### DIFF
--- a/lib/Crypt/Perl/ECDSA.pm
+++ b/lib/Crypt/Perl/ECDSA.pm
@@ -60,10 +60,12 @@ Crypt::Perl::ECDSA - Elliptic curve cryptography in pure Perl
     my $sig = $private->sign($msg_hash);
 
     # If you want deterministic signatures but also need to have more control
-    # over the hash you are signing, you can use this method. It requires a
-    # message hash, but will generate a deterministic signature using the hash
-    # function provided as second argument.
-    my $also_det_sig = $private->sign_deterministic($msg_hash, 'sha256');
+    # over the hash you are signing, you can use this method. It will sign the 
+    # message as passed (much like the sign() method), but will generate a 
+    # deterministic signature using the hash function provided as the second 
+    # argument.
+    my $fixed_hash = "\x00" x 32;
+    my $fixed_det_sig = $private->sign_deterministic($fixed_hash, 'sha256');
 
     #----------------------------------------------------------------------
 

--- a/lib/Crypt/Perl/ECDSA.pm
+++ b/lib/Crypt/Perl/ECDSA.pm
@@ -59,6 +59,12 @@ Crypt::Perl::ECDSA - Elliptic curve cryptography in pure Perl
     # Note that this signs a *digest*, not the message itself.
     my $sig = $private->sign($msg_hash);
 
+    # If you want deterministic signatures but also need to have more control
+    # over the hash you are signing, you can use this method. It requires a
+    # message hash, but will generate a deterministic signature using the hash
+    # function provided as second argument.
+    my $also_det_sig = $private->sign_deterministic($msg_hash, 'sha256');
+
     #----------------------------------------------------------------------
 
     $key->to_der_with_curve_name();

--- a/lib/Crypt/Perl/ECDSA.pm
+++ b/lib/Crypt/Perl/ECDSA.pm
@@ -60,12 +60,12 @@ Crypt::Perl::ECDSA - Elliptic curve cryptography in pure Perl
     my $sig = $private->sign($msg_hash);
 
     # If you want deterministic signatures but also need to have more control
-    # over the hash you are signing, you can use this method. It will sign the 
-    # message as passed (much like the sign() method), but will generate a 
-    # deterministic signature using the hash function provided as the second 
-    # argument.
+    # over the hash you are signing, you can use this method. It accepts a
+    # pre-hashed message (won't hash the message before signing it), but will
+    # generate a proper deterministic signature as if the message was hashed
+    # with the hash name given as a second argument.
     my $fixed_hash = "\x00" x 32;
-    my $fixed_det_sig = $private->sign_deterministic($fixed_hash, 'sha256');
+    my $fixed_det_sig = $private->sign_hash($fixed_hash, 'sha256');
 
     #----------------------------------------------------------------------
 

--- a/lib/Crypt/Perl/ECDSA/PrivateKey.pm
+++ b/lib/Crypt/Perl/ECDSA/PrivateKey.pm
@@ -140,6 +140,12 @@ sub sign {
     return $_[0]->_sign_and_serialize($_[1]);
 }
 
+sub sign_deterministic {
+    my ($self, $whatsit, $det_hashfuncname) = @_;
+
+    return $self->_sign_and_serialize($whatsit, $det_hashfuncname);
+}
+
 sub _sign_and_serialize {
     my ($self, $whatsit, $hashfn) = @_;
 

--- a/lib/Crypt/Perl/ECDSA/PrivateKey.pm
+++ b/lib/Crypt/Perl/ECDSA/PrivateKey.pm
@@ -140,7 +140,7 @@ sub sign {
     return $_[0]->_sign_and_serialize($_[1]);
 }
 
-sub sign_deterministic {
+sub sign_hash {
     my ($self, $whatsit, $det_hashfuncname) = @_;
 
     return $self->_sign_and_serialize($whatsit, $det_hashfuncname);

--- a/t/Crypt-Perl-ECDSA-PrivateKey.t
+++ b/t/Crypt-Perl-ECDSA-PrivateKey.t
@@ -309,6 +309,30 @@ sub test_sign : Tests() {
     return;
 }
 
+sub test_sign_deterministic : Tests(1) {
+    my $key_pem = <<END;
+-----BEGIN EC PRIVATE KEY-----
+MIHcAgEBBEIAv28oIsE2drCHfA3Jhkhc/kjsm2VcZywFpFAM1QuH/KmOu3iucI2r
+Q/bz2G3Fqhg4gSOq4Wo/WNkF+2djB49fGmmgBwYFK4EEACOhgYkDgYYABAHP4J5m
+Tvsh+RBJauItPWOOraBVslPOkAHp4aPHKKHCHSqvnc8Rd35hrd4qHGAEijehicrA
+eXThDZUZ9ampjgdyNgDlsIIYpL/kS7Ryx9bujpTsDPEa3zsRFmftoAuteT45n8Is
+X75cA6vjBy2iqZZDGCTCpB0qs8hakzocogUboszkzw==
+-----END EC PRIVATE KEY-----
+END
+
+    my $key = Crypt::Perl::ECDSA::Parse::private($key_pem);
+    my $msg = 'Deterministic signature test';
+
+    my $dgst = Digest::SHA::sha1($msg);
+
+    my $sig1 = $key->sign_sha1($msg);
+    my $sig2 = $key->sign_deterministic($dgst, 'sha1');
+
+    ok $sig1 eq $sig2, 'deterministic signatures match';
+
+    return;
+}
+
 sub test_jwa : Tests(9) {
     my ($self) = @_;
 

--- a/t/Crypt-Perl-ECDSA-PrivateKey.t
+++ b/t/Crypt-Perl-ECDSA-PrivateKey.t
@@ -309,7 +309,7 @@ sub test_sign : Tests() {
     return;
 }
 
-sub test_sign_deterministic : Tests(1) {
+sub test_sign_hash : Tests(1) {
     my $key_pem = <<END;
 -----BEGIN EC PRIVATE KEY-----
 MIHcAgEBBEIAv28oIsE2drCHfA3Jhkhc/kjsm2VcZywFpFAM1QuH/KmOu3iucI2r
@@ -321,12 +321,12 @@ X75cA6vjBy2iqZZDGCTCpB0qs8hakzocogUboszkzw==
 END
 
     my $key = Crypt::Perl::ECDSA::Parse::private($key_pem);
-    my $msg = 'Deterministic signature test';
+    my $msg = 'Deterministic signature of a hash test';
 
     my $dgst = Digest::SHA::sha1($msg);
 
     my $sig1 = $key->sign_sha1($msg);
-    my $sig2 = $key->sign_deterministic($dgst, 'sha1');
+    my $sig2 = $key->sign_hash($dgst, 'sha1');
 
     ok $sig1 eq $sig2, 'deterministic signatures match';
 


### PR DESCRIPTION
This should work well. I created a new test away from test_sign because it was hard to calculate how many tests it adds. Since this is deterministic signature, it should be the same as normal sign_$digest if the message is digested manually with $digest.

Resolves #17 